### PR TITLE
Add option to get binaries directly from OBS

### DIFF
--- a/osc-pod.py
+++ b/osc-pod.py
@@ -8,6 +8,31 @@ from osc import core
 from osc import oscerr
 
 
+class SimpleProgress:
+    """
+    Class with the same API as tqdm to use when the module is not
+    installed
+    """
+    def __init__(self, iterable):
+        self._iterable = iterable
+        self._size = len(self._iterable)
+        self._index = 0
+
+    def __iter__(self):
+        return self._iterable.__iter__()
+
+    def set_description(self, desc):
+        self._index += 1
+        p = (self._index / self._size) * 100
+        print(f'\r{desc} {p:.2f}% {self._index}/{self._size}', end='')
+
+
+try:
+    from tqdm import tqdm
+except ModuleNotFoundError:
+    tqdm = SimpleProgress
+
+
 repo2image = {
     'openSUSE_Factory': 'opensuse/tumbleweed',
     'openSUSE_Tumbleweed': 'opensuse/tumbleweed',
@@ -63,6 +88,8 @@ def store_read_last_buildroot() -> list[str]:
               help='use the specified platformstring, i.e., linux/amd64')
 @cmdln.option('-b', '--get-binaries', action='store_true',
               help='download binaries from obs')
+@cmdln.option('--repo',
+              help='Use this repo to download binaries')
 def do_pod(self, subcmd, opts, *args):
     """${cmd_name}: Run a container with the build rpms
 
@@ -95,6 +122,9 @@ def do_pod(self, subcmd, opts, *args):
     except oscerr.OscBaseError as e:
         repo, arch, runner = 'openSUSE_Factory', 'x86_64', ''
 
+    if opts.repo:
+        repo = opts.repo
+
     if args and len(args) > 1:
         raise oscerr.WrongArgs("Too many images!")
     elif args:
@@ -112,7 +142,10 @@ def do_pod(self, subcmd, opts, *args):
 
         bindir = tempfile.TemporaryDirectory()
         pacdir = bindir.name
+        print(f'Downloading {len(binaries)} binaries from {project}/{package or ""} {arch}')
+        binaries = tqdm(binaries)
         for b in binaries:
+            binaries.set_description(f'{b[:30]:<30}')
             core.get_binary_file(apiurl, project, repo, arch, b, package,
                                  target_filename=f'{pacdir}/{b}')
     else:

--- a/osc-pod.py
+++ b/osc-pod.py
@@ -84,10 +84,16 @@ def do_pod(self, subcmd, opts, *args):
     target: str = ''
     entrypoint: str = ''
 
-    package = core.store_read_package('.')
+    try:
+        package = core.store_read_package('.')
+    except oscerr.NoWorkingCopy as e:
+        package = None
     project = core.store_read_project('.')
 
-    repo, arch, runner = store_read_last_buildroot()
+    try:
+        repo, arch, runner = store_read_last_buildroot()
+    except oscerr.OscBaseError as e:
+        repo, arch, runner = 'openSUSE_Factory', 'x86_64', ''
 
     if args and len(args) > 1:
         raise oscerr.WrongArgs("Too many images!")


### PR DESCRIPTION
In this PR I'm adding a new option to download binaries directly from OBS so it's not needed to build locally. It also make it possible to run it in a project so it downloads all the binaries built there. Could be useful for home projects, to get all the binaries in a container.

Example:
```bash
$ cd devel:languages:python
$ osc pod -b -w --repo openSUSE_Tumbleweed tumbleweed
python-ephem-debugsource.rpm  :   2%|█                                | 204/8401 [00:57<15:15,  8.96it/s]
```